### PR TITLE
Added two minor QoL changes for special macros

### DIFF
--- a/Actions/UI/Dashboards/MacroDash.cs
+++ b/Actions/UI/Dashboards/MacroDash.cs
@@ -146,6 +146,7 @@ namespace Actions.UI.Dashboards
         {
             if (macro.Content.Contains("{user}") && !(_userManagerDash is null))
             {
+                if (!_userManagerDash.opened) _userManagerDash.Clicked();
                 _userManagerDash.SetSpecialMacro(macro);
                 return;
             }

--- a/Actions/UI/Dashboards/UserManagerDash.cs
+++ b/Actions/UI/Dashboards/UserManagerDash.cs
@@ -14,7 +14,6 @@ using UnityEngine.SceneManagement;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.FloatingScreen;
-using IPA.Utilities;
 
 namespace Actions.UI.Dashboards
 {

--- a/Actions/UI/Dashboards/UserManagerDash.cs
+++ b/Actions/UI/Dashboards/UserManagerDash.cs
@@ -72,7 +72,7 @@ namespace Actions.UI.Dashboards
         private IActionUser? _lastClickedUser;
         private string rootString = "";
         protected Macro? _specialMacro;
-        private bool opened = false;
+        public bool opened = false;
 
         public void Initialize()
         {
@@ -181,7 +181,7 @@ namespace Actions.UI.Dashboards
         }
 
         [UIAction("toggle")]
-        protected void Clicked()
+        public void Clicked()
         {
             _tweeningManager.KillAllTweens(this);
             var currentAlpha = userContainerCanvas.alpha;

--- a/Actions/Views/user-manager-dash.bsml
+++ b/Actions/Views/user-manager-dash.bsml
@@ -1,6 +1,9 @@
 ﻿<bg horizontal-fit="PreferredSize" vertical-fit="PreferredSize" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd">
   <vertical id="user-container" horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="75" pref-height="75">
-    <grid horizontal-fit="Unconstrained" vertical-fit="Unconstrained" child-align="MiddleLeft" cell-size-x="14" cell-size-y="14" spacing-x="1" spacing-y="1">
+    <vertical ignore-layout="true" anchor-pos-y="10">
+      <text active="~select-user" id="select-user-text" text="Select a user to use the macro on!" align="Center" font-color="#9C00FF"/>
+    </vertical>
+	<grid horizontal-fit="Unconstrained" vertical-fit="Unconstrained" child-align="MiddleLeft" cell-size-x="14" cell-size-y="14" spacing-x="1" spacing-y="1">
       <macro.for-each hosts="user-hosts">
         <clickable-image id="user-image" active="~has-content" on-click="clicked" pref-width="14" pref-height="14">
           <vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="14" pref-height="14">


### PR DESCRIPTION
The lack of visual indication for special macros annoyed me by a bit

Changelog

- If a special macro is used while the user dash is closed, it'll be automatically opened
- Text indicating to select a user will be enabled when a special macro is used