### PR TITLE
Updated to SiraUtil 3 and Beat Saber 1.19

### DIFF
--- a/Actions.sln
+++ b/Actions.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Actions", "Actions\Actions.csproj", "{04F62740-907A-4A7D-AC71-D65F58E5DF45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Actions", "Actions\Actions.csproj", "{04F62740-907A-4A7D-AC71-D65F58E5DF45}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Actions/Actions.csproj
+++ b/Actions/Actions.csproj
@@ -173,13 +173,14 @@
     </ItemGroup>
     
     <ItemGroup>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
         <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" Visible="false" />
         <None Include="Directory.Build.targets" Condition="Exists('Directory.Build.targets')" Visible="false" />
         <None Include="Actions.csproj.user" Condition="Exists('Actions.csproj.user')" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.3.2">
+      <PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.4.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Actions/Config.cs
+++ b/Actions/Config.cs
@@ -16,7 +16,7 @@ namespace Actions
     {
         public event Action<Config>? Updated;
 
-        [NonNullable, UseConverter(typeof(HiveVersionConverter))]
+        [NonNullable, UseConverter(typeof(VersionConverter))]
         public virtual Hive.Versioning.Version Version { get; set; } = new Hive.Versioning.Version("0.0.0");
 
         public virtual bool Enabled { get; set; } = true;
@@ -32,10 +32,10 @@ namespace Actions
 
         public virtual string Channel { get; set; } = "";
 
-        [UseConverter(typeof(Vector3Converter))] public Vector3 MacroDashboardPosition { get; set; } = new Vector3(1.2f, 1.5f, -1.5f);
-        [UseConverter(typeof(Vector3Converter))] public Vector3 MacroDashboardRotation { get; set; } = new Vector3(0f, 180f, 0f);
-        [UseConverter(typeof(Vector3Converter))] public Vector3 UserManagerDashboardPosition { get; set; } = new Vector3(-1.2f, 1.5f, -1.5f);
-        [UseConverter(typeof(Vector3Converter))] public Vector3 UserManagerDashboardRotation { get; set; } = new Vector3(0f, 180f, 0f);
+        public Vector3 MacroDashboardPosition { get; set; } = new Vector3(1.2f, 1.5f, -1.5f);
+        public Vector3 MacroDashboardRotation { get; set; } = new Vector3(0f, 180f, 0f);
+        public Vector3 UserManagerDashboardPosition { get; set; } = new Vector3(-1.2f, 1.5f, -1.5f);
+        public Vector3 UserManagerDashboardRotation { get; set; } = new Vector3(0f, 180f, 0f);
 
         public virtual void Changed()
         {

--- a/Actions/Dashboard/PlatformManager.cs
+++ b/Actions/Dashboard/PlatformManager.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Zenject;
-using SiraUtil.Tools;
+using SiraUtil.Logging;
 using System.Collections.Generic;
 
 namespace Actions.Dashboard

--- a/Actions/Installers/ActionsDashboardGameInstaller.cs
+++ b/Actions/Installers/ActionsDashboardGameInstaller.cs
@@ -1,14 +1,21 @@
 ﻿using System;
 using Zenject;
-using SiraUtil;
 using Actions.UI.Dashboards;
 
 namespace Actions.Installers
 {
-    public class ActionsDashboardInstaller : Installer
+    public class ActionsDashboardGameInstaller : Installer
     {
+        private readonly Config _config;
+        ActionsDashboardGameInstaller(Config config)
+        {
+            _config = config;
+        }
+
         public override void InstallBindings()
         {
+            if (!_config.ShowInGame)
+                return;
             Container.Bind(typeof(IInitializable), typeof(IDisposable), typeof(MacroDash)).To<MacroDash>().FromNewComponentAsViewController().AsSingle();
             Container.Bind(typeof(IInitializable), typeof(IDisposable), typeof(UserManagerDash)).To<UserManagerDash>().FromNewComponentAsViewController().AsSingle();
         }

--- a/Actions/Installers/ActionsDashboardMenuInstaller.cs
+++ b/Actions/Installers/ActionsDashboardMenuInstaller.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Zenject;
+using Actions.UI.Dashboards;
+
+namespace Actions.Installers
+{
+    public class ActionsDashboardMenuInstaller : Installer
+    {
+        public override void InstallBindings()
+        {
+            Container.Bind(typeof(IInitializable), typeof(IDisposable), typeof(MacroDash)).To<MacroDash>().FromNewComponentAsViewController().AsSingle();
+            Container.Bind(typeof(IInitializable), typeof(IDisposable), typeof(UserManagerDash)).To<UserManagerDash>().FromNewComponentAsViewController().AsSingle();
+        }
+    }
+}

--- a/Actions/Installers/ActionsMenuInstaller.cs
+++ b/Actions/Installers/ActionsMenuInstaller.cs
@@ -1,5 +1,4 @@
 ﻿using Zenject;
-using SiraUtil;
 using Actions.UI;
 using Actions.Managers;
 
@@ -14,7 +13,7 @@ namespace Actions.Installers
             Container.Bind<ActionMainView>().FromNewComponentAsViewController().AsSingle();
             Container.Bind<ActionMacroView>().FromNewComponentAsViewController().AsSingle();
 
-            Container.Bind<ActionFlowCoordinator>().FromNewComponentOnNewGameObject(nameof(ActionFlowCoordinator)).AsSingle();
+            Container.Bind<ActionFlowCoordinator>().FromNewComponentOnNewGameObject().AsSingle();
         }
     }
 }

--- a/Actions/Plugin.cs
+++ b/Actions/Plugin.cs
@@ -10,7 +10,7 @@ using IPALogger = IPA.Logging.Logger;
 
 namespace Actions
 {
-    [Plugin(RuntimeOptions.DynamicInit), Slog]
+    [Plugin(RuntimeOptions.DynamicInit), Slog, NoEnableDisable]
     public class Plugin
     {
         [Init]
@@ -19,19 +19,17 @@ namespace Actions
             Config config = conf.Generated<Config>();
             config.Version = metadata.HVersion;
 
-            zenjector
-                .On<PCAppInit>()
-                .Register<ActionsCoreInstaller>()
-                .Pseudo(Container =>
-                {
-                    Container.BindLoggerAsSiraLogger(log);
-                    Container.BindInstance(config).AsSingle();
-                    Container.BindInstance(metadata).WithId(nameof(Actions)).AsCached();
-                });
+            zenjector.UseLogger(log);
+            zenjector.Install<ActionsCoreInstaller>(Location.App);
+            zenjector.Install(Location.App, Container =>
+            {
+                Container.BindInstance(config).AsSingle();
+                Container.BindInstance(metadata).WithId(nameof(Actions)).AsCached();
+            });
 
-            zenjector.OnMenu<ActionsMenuInstaller>();
-            zenjector.OnMenu<ActionsDashboardInstaller>();
-            zenjector.OnGame<ActionsDashboardInstaller>().When(() => config.ShowInGame);
+            zenjector.Install<ActionsMenuInstaller>(Location.Menu);
+            zenjector.Install<ActionsDashboardMenuInstaller>(Location.Menu);
+            zenjector.Install<ActionsDashboardGameInstaller>(Location.Player);
         }
 
         [OnEnable, OnDisable]

--- a/Actions/Twitch/TwitchSocialPlatform.cs
+++ b/Actions/Twitch/TwitchSocialPlatform.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using Zenject;
 using ChatCore;
-using SiraUtil;
+using SiraUtil.Extras;
 using System.Linq;
 using IPA.Utilities;
-using SiraUtil.Tools;
+using SiraUtil.Logging;
 using Newtonsoft.Json;
 using System.Threading;
 using Actions.Dashboard;

--- a/Actions/UI/ActionMacroView.cs
+++ b/Actions/UI/ActionMacroView.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Actions.Dashboard;
 using Actions.UI.Dashboards;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
@@ -98,7 +99,7 @@ namespace Actions.UI
                 }
             }
             NotifyPropertyChanged(nameof(WithinLimit));
-            await SiraUtil.Utilities.PauseChamp;
+            await Task.Delay(100);
             macroTable.tableView.ReloadData();
         }
 

--- a/Actions/UI/ActionMainView.cs
+++ b/Actions/UI/ActionMainView.cs
@@ -94,7 +94,7 @@ namespace Actions.UI
         [UIAction("clicked-auros")]
         protected void ClickedAuros()
         {
-            Application.OpenURL("https://ko-fi.com/aurosnex");
+            Application.OpenURL("https://ko-fi.com/auros");
         }
     }
 }

--- a/Actions/UI/Dashboards/UserManagerDash.cs
+++ b/Actions/UI/Dashboards/UserManagerDash.cs
@@ -10,6 +10,7 @@ using Actions.Components;
 using System.ComponentModel;
 using BeatSaberMarkupLanguage;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine.SceneManagement;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.Attributes;
@@ -166,7 +167,7 @@ namespace Actions.UI.Dashboards
                 for (int i = 0; i < 10; i++)
                     userHosts.Add(new UserHost(UserClicked));
             }
-            await SiraUtil.Utilities.AwaitSleep(100);
+            await Task.Delay(100);
             base.DidActivate(firstActivation, addedToHierarchy, screenSystemEnabling);
             if (firstActivation)
             {

--- a/Actions/Views/macro-dash.bsml
+++ b/Actions/Views/macro-dash.bsml
@@ -1,13 +1,13 @@
 ﻿<bg xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd">
   <vertical id="macro-container" horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="75" pref-height="75">
-    <grid horizontal-fit="Unconstrained" vertical-fit="Unconstrained" child-align="MiddleRight" cell-size-x="24" cell-size-y="14" spacing-x="1" spacing-y="0.6">
-      <macro.for-each hosts="macro-hosts">
-        <button active="~has-content" text="~name" pref-width="24" pref-height="14" align="Center" on-click="clicked" />
-      </macro.for-each>
-    </grid>
+	<grid horizontal-fit="Unconstrained" vertical-fit="Unconstrained" child-align="MiddleRight" cell-size-x="24" cell-size-y="8" spacing-x="1" spacing-y="0.6">
+		<macro.for-each hosts="macro-hosts">
+			<button active="~has-content" text="~name" pref-width="24" pref-height="8" align="Center" on-click="clicked" />
+		</macro.for-each>
+	</grid>
     <vertical ignore-layout="true">
       <text id="nothing-text" text="It's rather empty here. Try creating a macro!" align="Center" />
     </vertical>
   </vertical>
-  <clickable-image src="Actions.Resources.purple-square.png" on-click="toggle" anchor-pos-x="45" size-delta-x="10" size-delta-y="10" />
+  <clickable-image src="Actions.Resources.purple-square.png" on-click="toggle" anchor-pos-x="45" size-delta-x="10" size-delta-y="10" hover-hint="Macros!" />
 </bg>

--- a/Actions/Views/main-view.bsml
+++ b/Actions/Views/main-view.bsml
@@ -2,7 +2,7 @@
   <vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize">
     <horizontal horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="85">
       <text text="~version" align="Left" font-size="5" face-color="grey" />
-      <clickable-text text="by Auros" align="Right" face-color="grey" hover-hint="Want to support me? Click this to open up my donation page in your browser." on-click="clicked-auros" />
+	  <clickable-text text="by Auros" align="Right" face-color="grey" hover-hint="Want to support me? Click this to open up my donation page in your browser." on-click="clicked-auros" />
     </horizontal>
     <vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="90">
       <image src="Actions.Resources.logo.png" pref-height="20" preserve-aspect="true" />

--- a/Actions/Views/user-manager-dash.bsml
+++ b/Actions/Views/user-manager-dash.bsml
@@ -13,7 +13,7 @@
       <text id="nothing-text" text="It's rather empty here. Try typing in chat." align="Center" />
     </vertical>
   </vertical>
-  <clickable-image src="Actions.Resources.red-square.png" on-click="toggle" anchor-pos-x="-45" size-delta-x="10" size-delta-y="10" />
+  <clickable-image src="Actions.Resources.red-square.png" on-click="toggle" anchor-pos-x="-45" size-delta-x="10" size-delta-y="10" hover-hint="Users!" />
   <modal size-delta-x="60" size-delta-y="35" show-event="show-modal" hide-event="hide-modal" clickerino-offerino-closerino="true">
     <vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="60" pref-height="35" pad="2">
       <vertical horizontal-fit="PreferredSize" vertical-fit="PreferredSize" pref-width="60" pad="2">

--- a/Actions/manifest.json
+++ b/Actions/manifest.json
@@ -3,13 +3,13 @@
   "id": "Actions",
   "name": "Actions",
   "author": "Auros",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Create and use macros in Beat Saber.",
-  "gameVersion": "1.18.0",
+  "gameVersion": "1.19.0",
   "dependsOn": {
     "BSIPA": "^4.2.0",
     "ChatCore": "^2.0.0",
-    "SiraUtil": "^2.3.1",
-    "BeatSaberMarkupLanguage": "^1.4.1"
+    "SiraUtil": "^3.0.3",
+    "BeatSaberMarkupLanguage": "^1.6.1"
   }
 }


### PR DESCRIPTION
Not very good at all this.
Referenced Changes to image factory to understand what was going on.

- Fixed a lot of changed class references in code to SiraUtil 3 class'
- Bumped BSIPA and SiraUtil versions in manifest.json
- Updated Auros ko-fi link in ActionsMainView.cs
- Squished buttons in macro-dash.bsml makes them a bit more compact.
- Added hover text to dashboard buttons to minimize confusion in macro-view.bsml and user-manager-dash.bsml
- switched from SiraUtil's PauseChamp class to Task.Delay(100) in ActionMacroView.cs
- seperated dashboard installer into "menuInstaller" and "gameInstaller" respectively to solve crash on startup if disable in game was set.

Tested fully functional in 1.19 with ChatCore 2.1.2, but let me know if i did a fuckywucky anywhere cause this is my first attempt at looking at any of this lol.